### PR TITLE
Prevent editing of transactions

### DIFF
--- a/src/pages/ExpensesView.jsx
+++ b/src/pages/ExpensesView.jsx
@@ -7,6 +7,13 @@ import { useAuth } from '../context/AuthContext';
 import { Plus, Filter, Search, ChevronLeft, ChevronRight, Trash2, Edit3, FileText } from 'lucide-react';
 import { exportExpensesToPDF } from '../utils/pdfExport';
 
+const LOCKED_TRANSFER_CATEGORIES = new Set([
+  'transfer sent',
+  'transfer received',
+  'request paid',
+  'request received',
+]);
+
 const ExpensesView = () => {
   const { user } = useAuth();
   const { showNotification } = useNotification();
@@ -128,6 +135,8 @@ const ExpensesView = () => {
     .filter((key) => Boolean(filters[key]))
     .length;
 
+  const isLockedTransferExpense = (item) => LOCKED_TRANSFER_CATEGORIES.has(String(item.category || '').trim().replace(/\s+/g, ' ').toLowerCase());
+
   return (
     <Layout>
       <div className="section-title">
@@ -246,8 +255,14 @@ const ExpensesView = () => {
                   </td>
                   <td style={{ textAlign: 'right' }}>
                     <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>
-                      <button className="btn" style={{ padding: '6px', background: 'none', color: 'var(--text-muted)' }} onClick={() => handleEdit(item.id)}><Edit3 size={18} /></button>
-                      <button className="btn" style={{ padding: '6px', background: 'none', color: 'var(--error)' }} onClick={() => handleDelete(item.id)}><Trash2 size={18} /></button>
+                      {!isLockedTransferExpense(item) ? (
+                        <>
+                          <button className="btn" style={{ padding: '6px', background: 'none', color: 'var(--text-muted)' }} onClick={() => handleEdit(item.id)}><Edit3 size={18} /></button>
+                          <button className="btn" style={{ padding: '6px', background: 'none', color: 'var(--error)' }} onClick={() => handleDelete(item.id)}><Trash2 size={18} /></button>
+                        </>
+                      ) : (
+                        <span style={{ color: 'var(--text-light)', fontSize: '0.82rem', fontWeight: 600 }}>Locked</span>
+                      )}
                     </div>
                   </td>
                 </tr>


### PR DESCRIPTION
This pull request introduces logic to lock certain transfer-related expense categories, preventing users from editing or deleting these entries in the `ExpensesView` page. The core changes add a set of locked categories, a utility function to check if an expense is locked, and update the UI to reflect the locked state by disabling edit/delete actions for these expenses.

**Locked transfer expense handling:**

* Defined a set of locked transfer categories in `LOCKED_TRANSFER_CATEGORIES` to identify which expenses should be protected from edits or deletion.
* Added the `isLockedTransferExpense` utility function to determine if a given expense falls into a locked category.

**UI updates:**

* Updated the action buttons in the expenses table to conditionally render edit/delete options or a "Locked" label based on whether the expense is in a locked transfer category.